### PR TITLE
Matrixify Q in PrecPartialSchurKrylovKit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BifurcationKit"
 uuid = "0f109fa4-8a5d-4b75-95aa-f515264e7665"
 authors = ["Romain Veltz <rveltz@salk.edu>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"

--- a/src/Preconditioner.jl
+++ b/src/Preconditioner.jl
@@ -44,7 +44,7 @@ Builds a preconditioner based on deflation of `nev` eigenvalues chosen according
 function PrecPartialSchurKrylovKit(J, x0, nev, which = :LM; krylovdim = max(2nev, 20), verbosity = 0)
 	H, V, vals, info = KrylovKit.schursolve(J, x0, nev, which, KrylovKit.Arnoldi(krylovdim = krylovdim, verbosity = verbosity))
 	Q, S = qr(H)
-	U = VectorOfArray(V) * Q
+	U = VectorOfArray(V) * Matrix(Q)
 	return PrecPartialSchur(S, U, inv(S), vals)
 end
 


### PR DESCRIPTION
This came up in a nanosoldier run related to https://github.com/JuliaLang/julia/pull/46196. It turns out that this product is falling back to `_generic_matmatmul!`, which computes the entries of `Q` one by one. The proposed change should make this step faster and this package invulnerable to the Julia PR.

After you accept the change, could you release a new version please so that nanosoldier can pick it up?