### PR TITLE
Fix outdated use of camelCase names, et cetera

### DIFF
--- a/examples/COModel.jl
+++ b/examples/COModel.jl
@@ -30,9 +30,9 @@ show(br)
 
 plot(br, plotfold=false, markersize=4, legend=:topright, ylims=(0,0.16))
 ####################################################################################################
-@set! opts_br.newtonOptions.verbose = false
-@set! opts_br.newtonOptions.maxIter = 10
-opts_br = @set opts_br.newtonOptions.tol = 1e-12
+@set! opts_br.newton_options.verbose = false
+@set! opts_br.newton_options.maxIter = 10
+opts_br = @set opts_br.newton_options.tol = 1e-12
 
 sn = newton(br, 3; options = opts_br.newton_options, bdlinsolver = MatrixBLS())
 

--- a/examples/SH2d-fronts.jl
+++ b/examples/SH2d-fronts.jl
@@ -94,7 +94,7 @@ optcont = @set optcont.newton_options.eigsolver = EigArpack(0.1, :LM)
 br = @time continuation(
     prob, PALC(), optcont;
     plot = true, verbosity = 3,
-    # finaliseSolution = (z, tau, step, contResult; k...) -> (Base.display(contResult.eig[end].eigenvals) ;true),
+    # finalise_solution = (z, tau, step, contResult; k...) -> (Base.display(contResult.eig[end].eigenvals) ;true),
     # callback_newton = cb,
     normC = norminf)
 ###################################################################################################
@@ -113,7 +113,7 @@ brfold = continuation(br, 1, (@lens _.ν), optfold;
     start_with_eigen = true,
     detect_codim2_bifurcation = 0,
     bothside = true,
-    # plotSolution = (x, p; kwargs...) -> (plotsol!((x.u); label="", kwargs...)),
+    # plot_solution = (x, p; kwargs...) -> (plotsol!((x.u); label="", kwargs...)),
     update_minaug_every_step = 1,
     )
 
@@ -158,9 +158,9 @@ diagram = bifurcationdiagram(br.prob, br, 2, optionsCont;
     plot = true, verbosity = 0,
     # usedeflation = true,
     # δp = 0.005,
-    # callbackN = cb,
-    # linearAlgo = MatrixBLS(),
-    # finaliseSolution = (z, tau, step, contResult; k...) ->     (Base.display(contResult.eig[end].eigenvals) ;true),
+    # callback_newton = cb,
+    # linear_algo = MatrixBLS(),
+    # finalise_solution = (z, tau, step, contResult; k...) ->     (Base.display(contResult.eig[end].eigenvals) ;true),
     normC = norminf,
     verbosediagram = true,
     )
@@ -175,8 +175,8 @@ algdc = BK.DefCont(deflation_operator = deflationOp, perturb_solution = (x,p,id)
 
 brdf = continuation(prob, algdc, setproperties(optcontdf; detect_bifurcation = 0, plot_every_step = 1);
     plot = true, verbosity = 2,
-    # finaliseSolution = (z, tau, step, contResult) ->     (Base.display(contResult.eig[end].eigenvals) ;true),
-    # callbackN = cb,
-    normN = x -> norm(x, Inf))
+    # finalise_solution = (z, tau, step, contResult) ->     (Base.display(contResult.eig[end].eigenvals) ;true),
+    # callback_newton = cb,
+    normC = x -> norm(x, Inf))
 
 plot(brdf...)

--- a/examples/SH3d.jl
+++ b/examples/SH3d.jl
@@ -145,7 +145,7 @@ br = @time continuation(
     plot = true, verbosity = 1,
     normC = norminf,
     event = BK.FoldDetectEvent,
-    # finaliseSolution = (z, tau, step, contResult; k...) -> begin
+    # finalise_solution = (z, tau, step, contResult; k...) -> begin
     #     if length(contResult) == 1
     #         pretty_table(contResult.branch)
     #     else
@@ -169,7 +169,7 @@ br1 = @time continuation(br, 3, setproperties(optcont; save_sol_every_step = 10,
         end
         true
     end,
-    # callbackN = cb,
+    # callback_newton = cb,
     normC = norminf)
 
 BK.plotBranch(br, br1...)

--- a/examples/SHpde_snaking.jl
+++ b/examples/SHpde_snaking.jl
@@ -58,12 +58,11 @@ end
 
 kwargsC = (verbosity = 3,
     plot = true,
-    # tangentAlgo = BorderedPred(),
     linear_algo  = MatrixBLS(),
     callback_newton = cb
     )
 
-brflat = @time continuation(prob, PALC(), opts; kwargsC..., verbosity = 0)
+brflat = @time continuation(prob, PALC(#=tangent=Bordered()=#), opts; kwargsC..., verbosity = 0)
 
 plot(brflat, putspecialptlegend = false)
 ####################################################################################################
@@ -89,14 +88,13 @@ diagram2 = bifurcationdiagram!(diagram.γ.prob, BK.get_branch(diagram, (2,)), 3,
 
 ####################################################################################################
 deflationOp = DeflationOperator(2, 1.0, [sol1.u])
-algdc = BK.DefCont(deflation_operator = deflationOp, max_branches = 50, perturb_solution = (sol, p, id) -> sol .+ 0.02 .* rand(length(sol)),)
+algdc = BK.DefCont(deflation_operator = deflationOp, max_branches = 50, perturb_solution = (sol, p, id) -> sol .+ 0.02 .* rand(length(sol)),#= alg = PALC(tangent=Secant())=#)
 
 br = @time continuation(
     re_make(prob, params = @set parSH.λ = -0.1), algdc,
     setproperties(opts; ds = 0.001, max_steps = 20000, p_max = 0.25, p_min = -1., newton_options = setproperties(optnew; tol = 1e-9, max_iterations = 15, verbose = false), save_sol_every_step = 0, detect_bifurcation = 0);
     verbosity = 1,
     normC = norminf,
-    # tangentAlgo = SecantPred(),
     # callback_newton = (x, f, J, res, iteration, itlinear, options; kwargs...) ->(true)
     )
 

--- a/examples/SHpde_snaking.jl
+++ b/examples/SHpde_snaking.jl
@@ -95,9 +95,9 @@ br = @time continuation(
     re_make(prob, params = @set parSH.λ = -0.1), algdc,
     setproperties(opts; ds = 0.001, max_steps = 20000, p_max = 0.25, p_min = -1., newton_options = setproperties(optnew; tol = 1e-9, max_iterations = 15, verbose = false), save_sol_every_step = 0, detect_bifurcation = 0);
     verbosity = 1,
-    normN = norminf,
+    normC = norminf,
     # tangentAlgo = SecantPred(),
-    # callbackN = (x, f, J, res, iteration, itlinear, options; kwargs...) ->(true)
+    # callback_newton = (x, f, J, res, iteration, itlinear, options; kwargs...) ->(true)
     )
 
 plot(br, legend=false, linewidth=1, vars = (:param, :n2))

--- a/examples/TMModel.jl
+++ b/examples/TMModel.jl
@@ -55,7 +55,7 @@ br_potrap = continuation(br, 4, opts_po_cont,
     PeriodicOrbitTrapProblem(M = 250, jacobian = :Dense, update_section_every_step = 0);
     verbosity = 2, plot = false,
     args_po...,
-    callbackN = BK.cbMaxNorm(10.),
+    callback_newton = BK.cbMaxNorm(10.),
     )
 
 plot(br, br_potrap, markersize = 3)
@@ -76,13 +76,13 @@ br_pocoll = @time continuation(
     verbosity = 2,
     plot = true,
     args_po...,
-    plotSolution = (x, p; k...) -> begin
+    plot_solution = (x, p; k...) -> begin
         xtt = BK.get_periodic_orbit(p.prob, x, p.p)
         plot!(xtt.t, xtt[1,:]; label = "", marker =:d, markersize = 1.5, k...)
         plot!(br; subplot = 1, putspecialptlegend = false)
 
     end,
-    callbackN = BK.cbMaxNorm(1000.),
+    callback_newton = BK.cbMaxNorm(1000.),
     )
 
 plot(br, br_pocoll, markersize = 3)
@@ -107,7 +107,7 @@ br_posh = @time continuation(
     # ShootingProblem(15, probsh, TaylorMethod(15), parallel = false);
     ampfactor = 1.0, δp = 0.0005,
     usedeflation = true,
-    linearAlgo = MatrixBLS(),
+    linear_algo = MatrixBLS(),
     verbosity = 2,    plot = true,
     args_po...,
     )
@@ -128,10 +128,10 @@ br_popsh = @time continuation(
     alg = PALC(tangent = Bordered()),
     ampfactor = 1.0, δp = 0.005,
     # usedeflation = true,
-    linearAlgo = MatrixBLS(),
+    linear_algo = MatrixBLS(),
     verbosity = 2, plot = true,
     args_po...,
-    callbackN = BK.cbMaxNorm(1e1),
+    callback_newton = BK.cbMaxNorm(1e1),
     record_from_solution = (x, p) -> (return (max = getmaximum(p.prob, x, @set par_tm.E0 = p.p), period = getperiod(p.prob, x, @set par_tm.E0 = p.p))),
     normC = norminf)
 

--- a/examples/brusselator.jl
+++ b/examples/brusselator.jl
@@ -90,8 +90,8 @@ par_bru = (α = 2., β = 5.45, D1 = 0.008, D2 = 0.004, l = 0.3)
 sol0 = vcat(par_bru.α * ones(n), par_bru.β/par_bru.α * ones(n))
 prob = BifurcationProblem(Fbru!, sol0, par_bru, (@lens _.l); 
         J = Jbru_sp, 
-        #plotSolution = (x, p; kwargs...) -> plotsol(x; label="", kwargs... ), 
-        # plotSolution = (ax, x, p) -> plotsol(ax, x), 
+        #plot_solution = (x, p; kwargs...) -> plotsol(x; label="", kwargs... ), 
+        # plot_solution = (ax, x, p) -> plotsol(ax, x), 
         record_from_solution = (x, p) -> x[div(n,2)])
 # # parameters for an isola of stationary solutions
 # par_bru = (α = 2., β = 4.6, D1 = 0.0016, D2 = 0.008, l = 0.061)
@@ -173,7 +173,7 @@ br_po = continuation(
         @info "Floquet exponents:"
         (Base.display(contResult.eig[end].eigenvals) ;true)
         end,
-    # plotSolution = (x, p; kwargs...) -> heatmap!(get_periodic_orbit(p.prob, x, par_bru).u'; ylabel="time", color=:viridis, kwargs...),
+    # plot_solution = (x, p; kwargs...) -> heatmap!(get_periodic_orbit(p.prob, x, par_bru).u'; ylabel="time", color=:viridis, kwargs...),
     normC = norminf)
 
 ####################################################################################################
@@ -192,7 +192,7 @@ br_po2 = BK.continuation(
     ########
     finalise_solution = (z, tau, step, contResult; k...) ->
         (Base.display(contResult.eig[end].eigenvals) ;true),
-    # plotSolution = (x, p; kwargs...) -> begin
+    # plot_solution = (x, p; kwargs...) -> begin
     #             heatmap!(get_periodic_orbit(p.prob, x, par_bru).u'; ylabel="time", color=:viridis, kwargs...)
     #             plot!(br_po,legend = :bottomright, subplot=1)
     #         end,

--- a/examples/brusselatorShooting.jl
+++ b/examples/brusselatorShooting.jl
@@ -104,7 +104,7 @@ br = @time continuation(
 #################################################################################################### Continuation of Periodic Orbit
 M = 10
 ind_hopf = 1
-l_hopf, Th, orbitguess2, hopfpt, vec_hopf = BK.guessFromHopf(br, ind_hopf, opts_br_eq.newton_options.eigsolver, M, 22*0.075)
+l_hopf, Th, orbitguess2, hopfpt, vec_hopf = BK.guess_from_hopf(br, ind_hopf, opts_br_eq.newton_options.eigsolver, M, 22*0.075)
 #
 orbitguess_f2 = reduce(hcat, orbitguess2)
 orbitguess_f = vcat(vec(orbitguess_f2), Th) |> vec

--- a/examples/cGL2d-shooting.jl
+++ b/examples/cGL2d-shooting.jl
@@ -157,7 +157,7 @@ br_po = @time continuation(probSh, outpo.u, PALC(),
         plot = true,
         linear_algo = MatrixFreeBLS(@set ls.N = probSh.M*2n+2),
         plot_solution = (x, p; kwargs...) -> heatmap!(reshape(x[1:Nx*Ny], Nx, Ny); color=:viridis, kwargs...),
-        # plotSolution = (ax, x, p; kwargs...) -> heatmap!(ax, reshape(x[1:Nx*Ny], Nx, Ny); kwargs...),
+        # plot_solution = (ax, x, p; kwargs...) -> heatmap!(ax, reshape(x[1:Nx*Ny], Nx, Ny); kwargs...),
         record_from_solution = (u, p; k...) -> (amp = BK.getamplitude(p.prob, u, (@set par_cgl.r = p.p); ratio = 2), period = u[end]),
         normC = norminf)
 
@@ -175,13 +175,13 @@ br_po = continuation(
     opts_po_cont,
     ShootingProblem(Mt, prob_sp, ETDRK2(krylov = true); abstol = 1e-10, reltol = 1e-8, jacobian = BK.FiniteDifferencesMF(),) ;
     verbosity = 3, plot = true, ampfactor = 1.5, δp = 0.01,
-    # callbackN = (x, f, J, res, iteration, itl, options; kwargs...) -> (println("--> amplitude = ", BK.amplitude(x, n, M; ratio = 2));true),
+    # callback_newton = (x, f, J, res, iteration, itl, options; kwargs...) -> (println("--> amplitude = ", BK.amplitude(x, n, M; ratio = 2));true),
     linear_algo = MatrixFreeBLS(@set ls.N = Mt*2n+2),
-    finaliseSolution = (z, tau, step, contResult; k...) ->begin
+    finalise_solution = (z, tau, step, contResult; k...) ->begin
         BK.haseigenvalues(contResult) && Base.display(contResult.eig[end].eigenvals)
         return true
     end,
-    plotSolution = (x, p; k...) -> heatmap!(reshape(x[1:Nx*Ny], Nx, Ny); color=:viridis, k...),
-    # plotSolution = (ax, x, p; kwargs...) -> heatmap!(ax, reshape(x[1:Nx*Ny], Nx, Ny); kwargs...),
-    recordFromSolution = (u, p; k...) -> (amp = BK.getamplitude(p.prob, u, (@set par_cgl.r = p.p); ratio = 2), period = u[end]),
+    plot_solution = (x, p; k...) -> heatmap!(reshape(x[1:Nx*Ny], Nx, Ny); color=:viridis, k...),
+    # plot_solution = (ax, x, p; kwargs...) -> heatmap!(ax, reshape(x[1:Nx*Ny], Nx, Ny); kwargs...),
+    record_from_solution = (u, p; k...) -> (amp = BK.getamplitude(p.prob, u, (@set par_cgl.r = p.p); ratio = 2), period = u[end]),
     normC = norminf)

--- a/examples/cGL2d.jl
+++ b/examples/cGL2d.jl
@@ -225,8 +225,8 @@ br_pok2 = continuation(PeriodicOrbitTrapProblem(poTrap; jacobian = :FullLU),
             orbitguess_f, PALC(),
             opts_po_cont;
             verbosity = 2,    plot = true,
-            plotSolution = (x ;kwargs...) -> plot_periodic_potrap(x, M, Nx, Ny; kwargs...),
-            recordFromSolution = (u, p) -> BK.amplitude(u, Nx*Ny, M), normC = norminf)
+            plot_solution = (x ;kwargs...) -> plot_periodic_potrap(x, M, Nx, Ny; kwargs...),
+            record_from_solution = (u, p) -> BK.amplitude(u, Nx*Ny, M), normC = norminf)
 ###################################################################################################
 # we use an ILU based preconditioner for the newton method at the level of the full Jacobian of the PO functional
 Jpo = @time poTrap(Val(:JacFullSparse), orbitguess_f, @set par_cgl.r = r_hopf - 0.01); # 0.5sec
@@ -250,8 +250,8 @@ opts_po_cont = ContinuationPar(dsmin = 0.0001, dsmax = 0.03, ds = 0.001, p_max =
 br_po = @time continuation(poTrapMF, outpo_f.u, PALC(), opts_po_cont;
         verbosity = 3,
         plot = true,
-        # plotSolution = (x, p;kwargs...) -> BK.plot_periodic_potrap(x, M, Nx, Ny; ratio = 2, kwargs...),
-        # recordFromSolution = (u, p) -> BK.amplitude(u, Nx*Ny, M; ratio = 2),
+        # plot_solution = (x, p;kwargs...) -> BK.plot_periodic_potrap(x, M, Nx, Ny; ratio = 2, kwargs...),
+        # record_from_solution = (u, p) -> BK.amplitude(u, Nx*Ny, M; ratio = 2),
         normC = norminf)
 
 branches = Any[br_pok2]

--- a/examples/carrier.jl
+++ b/examples/carrier.jl
@@ -93,7 +93,7 @@ brdc = @time continuation(
         p_max = 0.7, p_min = 0.05, detect_bifurcation = 0, plot_every_step = 40,
         newton_options = setproperties(optnew; tol = 1e-9, max_iterations = 100, verbose = false)),
     ;verbosity = 1,
-    normN = norminf,
+    normC = norminf,
     )
 
 plot(brdc, legend=true)#, marker=:d)

--- a/examples/chan-af.jl
+++ b/examples/chan-af.jl
@@ -93,7 +93,7 @@ plot(deflationOp.roots)
 # other dot product
 # dot(x::ApproxFun.Fun, y::ApproxFun.Fun) = sum(x * y) * length(x) # gives 0.1
 
-optcont = ContinuationPar(dsmin = 0.001, dsmax = 0.05, ds= 0.01, p_max = 4.1, plot_every_step = 10, newtonOptions = NewtonPar(tol = 1e-8, max_iterations = 20, verbose = true), max_steps = 300, θ = 0.2, detect_bifurcation = 0)
+optcont = ContinuationPar(dsmin = 0.001, dsmax = 0.05, ds= 0.01, p_max = 4.1, plot_every_step = 10, newton_options = NewtonPar(tol = 1e-8, max_iterations = 20, verbose = true), max_steps = 300, θ = 0.2, detect_bifurcation = 0)
 
     br = @time continuation(
         prob, PALC(bls=BorderingBLS(solver = optnew.linsolver, check_precision = false)), optcont;

--- a/examples/codim2PO-sh-mf.jl
+++ b/examples/codim2PO-sh-mf.jl
@@ -214,7 +214,7 @@ ns_po_sh = continuation(brpo_ns, 1, (@lens _.ϵ), opts_posh_ns;
         jacobian_ma = :minaug,
         # jacobian_ma = :autodiff,
         # jacobian_ma = :finiteDifferences,
-        normN = norminf,
+        normC = norminf,
         bothside = false,
         callback_newton = BK.cbMaxNorm(1),
         bdlinsolver = MatrixFreeBLS(@set lspo.N = lspo.N+2),

--- a/examples/codim2PO.jl
+++ b/examples/codim2PO.jl
@@ -115,7 +115,7 @@ pd_po_trap = continuation(brpo_pd, 1, (@lens _.b0), opts_potrap_pd;
         detect_codim2_bifurcation = 0,
         start_with_eigen = false,
         jacobian_ma = :finiteDifferences,
-        normN = norminf,
+        normC = norminf,
         callback_newton = BK.cbMaxNorm(1),
         # bdlinsolver = BorderingBLS(solver = DefaultLS(), check_precision = false),
         )
@@ -462,7 +462,7 @@ pd_po_sh2 = continuation(brpo_pd, 2, (@lens _.b0), opts_pocoll_pd;
         jacobian_ma = :minaug,
         # jacobian_ma = :autodiff,
         # jacobian_ma = :finiteDifferences,
-        normN = norminf,
+        normC = norminf,
         callback_newton = BK.cbMaxNorm(10),
         bothside = true,
         # bdlinsolver = BorderingBLS(solver = DefaultLS(), check_precision = false),

--- a/examples/mittleman.jl
+++ b/examples/mittleman.jl
@@ -233,7 +233,7 @@ solbif = newton(prob, bp2d.x0, bp2d(deflationOp[3], δp), (@set par_mit.λ = bp2
 plotsol(solbif.u-0*bp2d(deflationOp[2], δp))
 
 brnf1 = continuation(re_make(prob, u0 = solbif.u, params = (@set par_mit.λ = bp2d.p + δp)), PALC(), setproperties(opts_br; ds = 0.005);
-    plotSolution = (x, p; kwargs...) -> plotsol!(x ; kwargs...),
+    plot_solution = (x, p; kwargs...) -> plotsol!(x ; kwargs...),
     plot = true, verbosity = 3, normC = norminf)
 
 branches2 = Any[br,br1,br2,brnf1]
@@ -242,7 +242,7 @@ push!(branches2, brnf1)
 # plot!(brnf1)
 
 brnf2 = continuation(re_make(prob, u0 = solbif.u, params = (@set par_mit.λ = bp2d.p + δp)), PALC(), setproperties(opts_br; ds = -0.005);
-    plotSolution = (x, p; kwargs...) -> plotsol!(x ; kwargs...),
+    plot_solution = (x, p; kwargs...) -> plotsol!(x ; kwargs...),
     plot = true, verbosity = 3, normC = norminf)
 
 # plot([br,br1,br2]);plot!(brnf1);plot!(brnf2)
@@ -286,8 +286,8 @@ brdef2 = @time BK.continuation(
     re_make(brdef1.prob, u0 = deflationOp[5]), PALC(),
     setproperties(opts_br;ds = -0.001, detect_bifurcation = 0, dsmax = 0.02);
     verbosity = 3, plot = true,
-    recordFromSolution = (x, p) ->  normbratu(x),
-    plotSolution = (x, p; kwargs...) -> plotsol!(x ; kwargs...), normC = norminf)
+    record_from_solution = (x, p) ->  normbratu(x),
+    plot_solution = (x, p; kwargs...) -> plotsol!(x ; kwargs...), normC = norminf)
 
 plot(br,br1,br2, brdef1, brdef2,plotfold=false, putspecialptlegend = false)
 
@@ -301,6 +301,6 @@ brdef2 = @time BK.continuation(
     (@set prob.params.λ = 0.367), algdc,
     ContinuationPar(opts_br; ds = -0.0001, max_steps = 800000, plot_every_step = 10, detect_bifurcation = 0);
     plot=true, verbosity = 2,
-    normN = norminf)
+    normC = norminf)
 
 plot(brdef2, color=:red)

--- a/examples/pd-1d.jl
+++ b/examples/pd-1d.jl
@@ -111,10 +111,9 @@ br_po = @time continuation(
     # ampfactor is a factor to increase the amplitude of the guess
     verbosity = 2,
     plot = true,
-    normN = norminf,
-    callbackN = BK.cbMaxNorm(1e2),
-    plotSolution = (x, p;kwargs...) ->  (heatmap!(reshape(x[1:end-1], 2*N, M)'; ylabel="time", color=:viridis, kwargs...);plot!(br, subplot=1)),
-    recordFromSolution = (u, p) -> (max = maximum(u[1:end-1]), period = u[end]),#BK.maximumPOTrap(u, N, M; ratio = 2),
+    callback_newton = BK.cbMaxNorm(1e2),
+    plot_solution = (x, p;kwargs...) ->  (heatmap!(reshape(x[1:end-1], 2*N, M)'; ylabel="time", color=:viridis, kwargs...);plot!(br, subplot=1)),
+    record_from_solution = (u, p) -> (max = maximum(u[1:end-1]), period = u[end]),#BK.maximumPOTrap(u, N, M; ratio = 2),
     normC = norminf)
 
 plot(br, br_po, label = "")
@@ -130,12 +129,11 @@ br_po_pd = @time continuation(
     ampfactor = 0.9, δp = -0.01,
     verbosity = 3,
     plot = true,
-    normN = norminf,
-    callbackN = BK.cbMaxNorm(1e2),
+    callback_newton = BK.cbMaxNorm(1e2),
     # jacobianPO = :FullSparseInplace,
     # jacobianPO = :BorderedSparseInplace,
-    plotSolution = (x, p;kwargs...) ->  (heatmap!(reshape(x[1:end-1], 2*N, M)'; ylabel="time", color=:viridis, kwargs...);plot!(br_po, subplot=1)),
-    recordFromSolution = (u, p) -> (max = maximum(u[1:end-1]), period = u[end]),#BK.maximumPOTrap(u, N, M; ratio = 2),
+    plot_solution = (x, p;kwargs...) ->  (heatmap!(reshape(x[1:end-1], 2*N, M)'; ylabel="time", color=:viridis, kwargs...);plot!(br_po, subplot=1)),
+    record_from_solution = (u, p) -> (max = maximum(u[1:end-1]), period = u[end]),#BK.maximumPOTrap(u, N, M; ratio = 2),
     normC = norminf)
 
 plot(br, br_po, br_po_pd, label = "")
@@ -178,10 +176,10 @@ optcontpo = ContinuationPar(dsmin = 0.0001, dsmax = 0.01, ds= -0.005, p_min = -1
 br_po_sh = @time continuation(probSh, outposh.u, PALC(), optcontpo;
     verbosity = 3,    plot = true,
     linear_algo = MatrixFreeBLS(@set ls.N = probSh.M*n+2),
-    finaliseSolution = (z, tau, step, contResult; kw...) ->
+    finalise_solution = (z, tau, step, contResult; kw...) ->
         (BK.haseigenvalues(contResult) && Base.display(contResult.eig[end].eigenvals) ;true),
-    plotSolution = (x, p; kwargs...) -> BK.plot_periodic_shooting!(x[1:end-1], 1; kwargs...),
-    recordFromSolution = (u, p) -> BK.getmaximum(probSh, u, (@set par_br_hopf.C = p.p); ratio = 2), normC = norminf)
+    plot_solution = (x, p; kwargs...) -> BK.plot_periodic_shooting!(x[1:end-1], 1; kwargs...),
+    record_from_solution = (u, p) -> BK.getmaximum(probSh, u, (@set par_br_hopf.C = p.p); ratio = 2), normC = norminf)
 
 # branches = [br_po_sh]
 # push!(branches, br_po_sh)

--- a/src/BifurcationPoints.jl
+++ b/src/BifurcationPoints.jl
@@ -48,7 +48,7 @@ $(TYPEDFIELDS)
     "Norm of the equilibrium at the special point"
     norm::T  = 0.
 
-    "`printsol = recordFromSolution(x, param)` where `recordFromSolution` is one of the arguments to [`continuation`](@ref)"
+    "`printsol = record_from_solution(x, param)` where `record_from_solution` is one of the arguments to [`continuation`](@ref)"
     printsol::Tp = 0.
 
     "Equilibrium at the special point"

--- a/src/Continuation.jl
+++ b/src/Continuation.jl
@@ -11,8 +11,8 @@ $(TYPEDEF)
 - `save_eigenvectors(iter)` whether to save eigen vectors
 - `getparams(iter)` get full list of params
 - `length(iter)`
-- `isindomain(iter, p)` whether `p` in is domain [pMin, pMax]. (See [`ContinuationPar`](@ref))
-- `is_on_boundary(iter, p)` whether `p` in is {pMin, pMax}
+- `isindomain(iter, p)` whether `p` in is domain [p_min, p_max]. (See [`ContinuationPar`](@ref))
+- `is_on_boundary(iter, p)` whether `p` in is {p_min, p_max}
 """
 @with_kw_noshow struct ContIterable{Tkind <: AbstractContinuationKind, Tprob, Talg, T, S, E, TnormC, Tfinalisesolution, TcallbackN, Tevent} <: AbstractContinuationIterable{Tkind}
     kind::Tkind
@@ -493,7 +493,7 @@ Compute the continuation curve associated to the functional `F` which is stored 
 - `plot = false` whether to plot the solution/branch/spectrum while computing the branch
 - `bothside = true` compute the branches on the two sides of `p0`, merge them and return it.
 - `finalise_solution = (z, tau, step, contResult; kwargs...) -> true` Function called at the end of each continuation step. Can be used to alter the continuation procedure (stop it by returning `false`), saving personal data, plotting... The notations are ``z=(x, p)`` where `x` (resp. `p`) is the current solution (resp. parameter value), `tau` is the tangent at `z`, `step` is the index of the current continuation step and `ContResult` is the current branch. For advanced use, the current `state::ContState` of the continuation is passed in `kwargs`. Note that you can have a better control over the continuation procedure by using an iterator, see [Iterator Interface](@ref).
-- `verbosity::Int = 0` controls the amount of information printed during the continuation process. Must belong to `{0,1,2,3}`. In case `contparams.newtonOptions.verbose = false`, the following is valid (otherwise the newton iterations are shown). Each case prints more information than the previous one:
+- `verbosity::Int = 0` controls the amount of information printed during the continuation process. Must belong to `{0,1,2,3}`. In case `contparams.newton_options.verbose = false`, the following is valid (otherwise the newton iterations are shown). Each case prints more information than the previous one:
     - case 0: print nothing
     - case 1: print basic information about the continuation: used predictor, step size and parameter values
     - case 2: print newton iterations number, stability of solution, detected bifurcations / events

--- a/src/DeflatedContinuation.jl
+++ b/src/DeflatedContinuation.jl
@@ -172,7 +172,7 @@ Depending on the options in `contParams`, it can locate the bifurcation points o
 - `plot = false` whether to plot the solution while computing,
 - `callback_newton` callback for newton iterations. see docs for `newton`. Can be used to change preconditioners or affect the newton iterations. In the deflation part of the algorithm, when seeking for new branches, the callback is passed the keyword argument `fromDeflatedNewton = true` to tell the user can it is not in the continuation part (regular newton) of the algorithm,
 - `verbosity::Int` controls the amount of information printed during the continuation process. Must belong to `{0,⋯,5}`,
-- `normN = norm` norm used in the Newton solves,
+- `normC = norm` norm used in the Newton solves,
 - `dot_palc = (x, y) -> dot(x, y) / length(x)`, dot product used to define the weighted dot product (resp. norm) ``\\|(x, p)\\|^2_\\theta`` in the constraint ``N(x, p)`` (see online docs on [PALC](https://bifurcationkit.github.io/BifurcationKitDocs.jl/dev/PALC/)). This argument can be used to remove the factor `1/length(x)` for example in problems where the dimension of the state space changes (mesh adaptation, ...),
 
 # Outputs:
@@ -187,7 +187,7 @@ function continuation(prob::AbstractBifurcationProblem,
             dot_palc = DotTheta(),
             callback_newton = cb_default,
             filename = "branch-" * string(Dates.now()),
-            normN = norm,
+            normC = norm,
             kwcont...)
 
     algdc = @set algdc.max_iter_defop = algdc.max_iter_defop * contParams.newton_options.max_iterations
@@ -202,10 +202,10 @@ function continuation(prob::AbstractBifurcationProblem,
     verbosity > 0 && printstyled(color=:magenta, "──▶ There are $(length(deflationOp)) branche(s)\n")
 
     # underlying continuation iterator
-    # we "hack" the saveSolEveryStep option because we always want to record the first point on each branch
+    # we "hack" the save_sol_every_step option because we always want to record the first point on each branch
     contIt = ContIterable(prob, algdc.alg, ContinuationPar(contParams, save_sol_every_step = contParams.save_sol_every_step == 0 ? Int(1e14) : contParams.save_sol_every_step);
                     plot = plot,
-                    normC = normN,
+                    normC = normC,
                     callback_newton = callback_newton,
                     verbosity = verbosity-2,
                     kwcont...)

--- a/src/DeflationOperator.jl
+++ b/src/DeflationOperator.jl
@@ -1,4 +1,4 @@
-abstract type abstractDeflationFactor end
+abstract type AbstractDeflationFactor end
 
 """
 Wrapper for a distance. You need to pass a function `d(u, v)`.
@@ -38,7 +38,7 @@ You are asked to pass a scalar product like `dot` to build a `DeflationOperator`
 
 Note that passing `CustomDist(dist, true)` will trigger the use of automatic differentiation for the gradient of `M`.
 """
-struct DeflationOperator{Tp <: Real, Tdot, T <: Real, vectype} <: abstractDeflationFactor
+struct DeflationOperator{Tp <: Real, Tdot, T <: Real, vectype} <: AbstractDeflationFactor
     "power `p`. You can use an `Int` for example"
     power::Tp
 

--- a/src/NormalForms.jl
+++ b/src/NormalForms.jl
@@ -485,7 +485,7 @@ function get_normal_form(prob::AbstractBifurcationProblem,
 
     # bifurcation point
     if ~(bifpt.x isa Teigvec)
-        @error "The type of the equilibrium $(typeof(bifpt.x)) does not match the one of the eigenvectors $(Teigvec). You can keep your choice by using the option `Teigvec` in `getNormalForm` to specify the type of the equilibrum."
+        @error "The type of the equilibrium $(typeof(bifpt.x)) does not match the one of the eigenvectors $(Teigvec). You can keep your choice by using the option `Teigvec` in `get_normal_form` to specify the type of the equilibrum."
     end
     x0 = convert(Teigvec, bifpt.x)
     p = bifpt.param
@@ -512,7 +512,7 @@ function get_normal_form(prob::AbstractBifurcationProblem,
             # we recompute the eigen-elements if there were not saved during the computation of the branch
             _λ, _ev, _ = options.eigsolver(L, length(rightEv))
             verbose && (println("──> (λs, λs (recomputed)) = "); display(hcat(rightEv, _λ[eachindex(rightEv)])))
-            if norm(_λ[eachindex(rightEv)] - rightEv, Inf) > br.contparams.tolStability
+            if norm(_λ[eachindex(rightEv)] - rightEv, Inf) > br.contparams.tol_stability
                 @warn "We did not find the correct eigenvalues (see 1st col). We found the eigenvalues displayed in the second column:\n $(display(hcat(rightEv, _λ[eachindex(rightEv)]))).\n Difference between the eigenvalues:" display(_λ[eachindex(rightEv)] - rightEv)
             end
             ζs = [copy(geteigenvector(options.eigsolver, _ev, ii)) for ii in indev-N+1:indev]

--- a/src/Problems.jl
+++ b/src/Problems.jl
@@ -114,9 +114,9 @@ for op in (:BifurcationProblem,
 
             ## Methods
 
-            - `reMake(pb; kwargs...)` modify a bifurcation problem
+            - `re_make(pb; kwargs...)` modify a bifurcation problem
             - `getu0(pb)` calls `pb.u0`
-            - `petParams(pb)` calls `pb.params`
+            - `getparams(pb)` calls `pb.params`
             - `getlens(pb)` calls `pb.lens`
             - `getparam(pb)` calls `get(pb.params, pb.lens)`
             - `setparam(pb, p0)` calls `set(pb.params, pb.lens, p0)`

--- a/src/Results.jl
+++ b/src/Results.jl
@@ -26,7 +26,7 @@ $(TYPEDFIELDS)
 - `show(br)` display information about the branch
 - `eigenvals(br, ind)` returns the eigenvalues for the ind-th continuation step
 - `eigenvec(br, ind, indev)` returns the indev-th eigenvector for the ind-th continuation step
-- `getNormalForm(br, ind)` compute the normal form of the ind-th points in `br.specialpoint`
+- `get_normal_form(br, ind)` compute the normal form of the ind-th points in `br.specialpoint`
 - `getlens(br)` return the parameter axis used for the branch
 - `getlenses(br)` return the parameter two axis used for the branch when 2 parameters continuation is used (Fold, Hopf, NS, PD)
 - `br[k+1]` gives information about the k-th step. A typical run yields the following
@@ -59,7 +59,7 @@ julia> br.param
 - `continuation(br, ind, probPO::AbstractPeriodicOrbitProblem)` performs aBS from ind-th bifurcation point (which must be a Hopf bifurcation point) to branch of periodic orbits.
 """
 @with_kw_noshow struct ContResult{Tkind <: AbstractContinuationKind, Tbr, Teigvals, Teigvec, Biftype, Tsol, Tparc, Tprob, Talg} <: AbstractResult{Tkind, Tprob}
-    "holds the low-dimensional information about the branch. More precisely, `branch[i+1]` contains the following information `(recordFromSolution(u, param), param, itnewton, itlinear, ds, θ, n_unstable, n_imag, stable, step)` for each continuation step `i`.\n
+    "holds the low-dimensional information about the branch. More precisely, `branch[i+1]` contains the following information `(record_from_solution(u, param), param, itnewton, itlinear, ds, θ, n_unstable, n_imag, stable, step)` for each continuation step `i`.\n
   - `itnewton` number of Newton iterations
   - `itlinear` total number of linear iterations during newton (corrector)
   - `n_unstable` number of eigenvalues with positive real part for each continuation step (to detect stationary bifurcation)
@@ -71,7 +71,7 @@ julia> br.param
     "A vector with eigen-elements at each continuation step."
     eig::Vector{NamedTuple{(:eigenvals, :eigenvecs, :converged, :step), Tuple{Teigvals, Teigvec, Bool, Int64}}}
 
-    "Vector of solutions sampled along the branch. This is set by the argument `saveSolEveryStep::Int64` (default 0) in [`ContinuationPar`](@ref)."
+    "Vector of solutions sampled along the branch. This is set by the argument `save_sol_every_step::Int64` (default 0) in [`ContinuationPar`](@ref)."
     sol::Tsol
 
     "The parameters used for the call to `continuation` which produced this branch. Must be a [`ContinuationPar`](@ref)"
@@ -130,7 +130,7 @@ $(SIGNATURES)
 Return the solution for the ind-th point stored in br.sol
 """
 @inline function get_solx(br::ContResult, ind::Int)
-    @assert hassolution(br) "You did not record the solution in the branch. Please set `saveSolEveryStep` in `ContinuationPar`"
+    @assert hassolution(br) "You did not record the solution in the branch. Please set `save_sol_every_step` in `ContinuationPar`"
     return br.sol[ind].x
 end
 
@@ -140,7 +140,7 @@ $(SIGNATURES)
 Return the parameter for the ind-th point stored in br.sol
 """
 @inline function get_solp(br::ContResult, ind::Int)
-    @assert hassolution(br) "You did not record the solution in the branch. Please set `saveSolEveryStep` in `ContinuationPar`"
+    @assert hassolution(br) "You did not record the solution in the branch. Please set `save_sol_every_step` in `ContinuationPar`"
     return br.sol[ind].p
 end
 
@@ -218,7 +218,7 @@ $(SIGNATURES)
 Function is used to initialize the composite type `ContResult` according to the options contained in `contParams`
 
 # Arguments
-- `br` result from `getStateSummary`
+- `br` result from `get_state_summary`
 - `par`: parameters
 - `lens`: lens to specify the continuation parameter
 - `eiginfo`: eigen-elements (eigvals, eigvecs)

--- a/src/bifdiagram/BifurcationDiagram.jl
+++ b/src/bifdiagram/BifurcationDiagram.jl
@@ -39,14 +39,14 @@ _size(tree::BifDiagNode) = length(tree.child) > 0 ? 1 + mapreduce(size, +, tree.
 """
 $(SIGNATURES)
 
-Return the size of the bifurcation diagram. The argument `code` is the same as in `getBranch`.
+Return the size of the bifurcation diagram. The argument `code` is the same as in `get_branch`.
 """
 Base.size(tree::BifDiagNode, code = ()) = _size(get_branch(tree, code))
 
 """
 $(SIGNATURES)
 
-Return the part of the tree (bifurcation diagram) by recursively descending down the tree using the `Int` valued tuple `code`. For example `getBranch(tree, (1,2,3,))` returns `tree.child[1].child[2].child[3]`.
+Return the part of the tree (bifurcation diagram) by recursively descending down the tree using the `Int` valued tuple `code`. For example `get_branch(tree, (1,2,3,))` returns `tree.child[1].child[2].child[3]`.
 """
 function get_branch(tree::BifDiagNode, code)
     isempty(code) && return tree
@@ -99,7 +99,7 @@ end
 """
 $(SIGNATURES)
 
-Similar to [`bifurcationdiagram`](@ref) but you pass a previously computed `node` from which you want to further compute the bifurcated branches. It is usually used with `node = getBranch(diagram, code)` from a previously computed bifurcation `diagram`.
+Similar to [`bifurcationdiagram`](@ref) but you pass a previously computed `node` from which you want to further compute the bifurcated branches. It is usually used with `node = get_branch(diagram, code)` from a previously computed bifurcation `diagram`.
 
 # Arguments
 - `node::BifDiagNode` a node in the bifurcation diagram
@@ -130,7 +130,7 @@ function bifurcationdiagram!(prob::AbstractBifurcationProblem,
 
     # convenient function for branching
     function letsbranch(_id, _pt, _level; _dsfactor = 1, _ampfactor = 1)
-        plotfunc = get(kwargs, :plotSolution, (x, p; kws...) -> plot!(x; kws...))
+        plotfunc = get(kwargs, :plot_solution, (x, p; kws...) -> plot!(x; kws...))
         optscont = options(_pt.x, _pt.param, _level + 1)
         @set! optscont.ds *= _dsfactor
 

--- a/src/bifdiagram/BranchSwitching.jl
+++ b/src/bifdiagram/BranchSwitching.jl
@@ -55,8 +55,8 @@ Automatic branch switching at branch points based on a computation of the normal
 - `perturb = identity` which perturbation function to use during deflated newton
 - `Teigvec = getvectortype(br)` type of the eigenvector. Useful when `br` was loaded from a file and this information was lost
 - `scaleζ = norm` pass a norm to normalize vectors during normal form computation
-- `plotSolution` change plot solution method in the problem `br.prob`
-- `kwargs` optional arguments to be passed to [`continuation`](@ref), the regular `continuation` one and to [`getNormalForm`](@ref).
+- `plot_solution` change plot solution method in the problem `br.prob`
+- `kwargs` optional arguments to be passed to [`continuation`](@ref), the regular `continuation` one and to [`get_normal_form`](@ref).
 
 !!! tip "Advanced use"
     In the case of a very large model and use of special hardware (GPU, cluster), we suggest to discouple the computation of the reduced equation, the predictor and the bifurcated branches. Have a look at `methods(BifurcationKit.multicontinuation)` to see how to call these versions. These methods has been tested on GPU with very high memory pressure.
@@ -118,7 +118,7 @@ function continuation(br::AbstractResult{EquilibriumCont, Tprob}, ind_bif::Int, 
 end
 
 # same but for a Branch
-continuation(br::AbstractBranchResult, ind_bif::Int, options_cont::ContinuationPar = br.contparams ; kwargs...) = continuation(getContResult(br), ind_bif, options_cont ; kwargs...)
+continuation(br::AbstractBranchResult, ind_bif::Int, options_cont::ContinuationPar = br.contparams ; kwargs...) = continuation(get_contresult(br), ind_bif, options_cont ; kwargs...)
 
 """
 $(SIGNATURES)
@@ -215,8 +215,8 @@ function get_first_points_on_branch(br::AbstractBranchResult,
     optn = options_cont.newton_options
 
     # options for newton
-    cbnewton = get(kwargs, :callbackN, cb_default)
-    normn = get(kwargs, :normN, norm)
+    cbnewton = get(kwargs, :callback_newton, cb_default)
+    normn = get(kwargs, :normC, norm)
 
     printstyled(color = :magenta, "──▶ Looking for solutions after the bifurcation point...\n")
     defOpp = DeflationOperator(2, 1.0, Vector{typeof(bpnf.x0)}(), _copy(bpnf.x0); autodiff = true)
@@ -330,4 +330,4 @@ function multicontinuation(br::AbstractBranchResult,
 end
 
 # same but for a Branch
-multicontinuation(br::Branch, ind_bif::Int, options_cont::ContinuationPar = br.contparams; kwargs...) = multicontinuation(getContResult(br), ind_bif, options_cont ; kwargs...)
+multicontinuation(br::Branch, ind_bif::Int, options_cont::ContinuationPar = br.contparams; kwargs...) = multicontinuation(get_contresult(br), ind_bif, options_cont ; kwargs...)

--- a/src/codim2/MinAugFold.jl
+++ b/src/codim2/MinAugFold.jl
@@ -280,12 +280,12 @@ Codim 2 continuation of Fold points. This function turns an initial guess for a 
 - `jacobian_ma::Symbol = :autodiff`, how the linear system of the Fold problem is solved. Can be `:autodiff, :finiteDifferencesMF, :finiteDifferences, :minaug`
 - `bdlinsolver` bordered linear solver for the constraint equation
 - `update_minaug_every_step` update vectors `a, b` in Minimally Formulation every `update_minaug_every_step` steps
-- `compute_eigen_elements = false` whether to compute eigenelements. If `options_cont.detectEvent>0`, it allows the detection of ZH points.
+- `compute_eigen_elements = false` whether to compute eigenelements. If `options_cont.detect_event>0`, it allows the detection of ZH points.
 - `kwargs` keywords arguments to be passed to the regular [`continuation`](@ref)
 
 # Simplified call
 
-    continuationFold(br::AbstractBranchResult, ind_fold::Int64, lens2::Lens, options_cont::ContinuationPar ; kwargs...)
+    continuation_fold(br::AbstractBranchResult, ind_fold::Int64, lens2::Lens, options_cont::ContinuationPar ; kwargs...)
 
 where the parameters are as above except that you have to pass the branch `br` from the result of a call to `continuation` with detection of bifurcations enabled and `index` is the index of Fold point in `br` that you want to continue.
 
@@ -296,7 +296,7 @@ where the parameters are as above except that you have to pass the branch `br` f
     For ODE problems, it is more efficient to use the Matrix based Bordered Linear Solver passing the option `bdlinsolver = MatrixBLS()`
 
 !!! tip "Detection of Bogdanov-Takens and Cusp bifurcations"
-    In order to trigger the detection, pass `detectEvent = 1,2` in `options_cont`.
+    In order to trigger the detection, pass `detect_event = 1,2` in `options_cont`.
 """
 function continuation_fold(prob, alg::AbstractContinuationAlgorithm,
                 foldpointguess::BorderedArray{vectype, T}, par,

--- a/src/codim2/MinAugHopf.jl
+++ b/src/codim2/MinAugHopf.jl
@@ -1,5 +1,5 @@
 """
-For an initial guess from the index of a Hopf bifurcation point located in ContResult.specialpoint, returns a point which can be refined using `newtonHopf`.
+For an initial guess from the index of a Hopf bifurcation point located in ContResult.specialpoint, returns a point which can be refined using `newton_hopf`.
 """
 function HopfPoint(br::AbstractBranchResult, index::Int)
     @assert br.specialpoint[index].type == :hopf "The provided index does not refer to a Hopf point"
@@ -197,7 +197,7 @@ This function turns an initial guess for a Hopf point into a solution to the Hop
 # Simplified call:
 Simplified call to refine an initial guess for a Hopf point. More precisely, the call is as follows
 
-    newtonHopf(br::AbstractBranchResult, ind_hopf::Int; normN = norm, options = br.contparams.newton_options, kwargs...)
+    newton_hopf(br::AbstractBranchResult, ind_hopf::Int; normN = norm, options = br.contparams.newton_options, kwargs...)
 
 The parameters / options are as usual except that you have to pass the branch `br` from the result of a call to `continuation` with detection of bifurcations enabled and `index` is the index of bifurcation point in `br` you want to refine. You can pass newton parameters different from the ones stored in `br` by using the argument `options`.
 
@@ -290,12 +290,12 @@ codim 2 continuation of Hopf points. This function turns an initial guess for a 
 - `jacobian_ma::Symbol = :autodiff`, how the linear system of the Fold problem is solved. Can be `:autodiff, :finiteDifferencesMF, :finiteDifferences, :minaug`
 - `bdlinsolver` bordered linear solver for the constraint equation
 - `update_minaug_every_step` update vectors `a,b` in Minimally Formulation every `update_minaug_every_step` steps
-- `compute_eigen_elements = false` whether to compute eigenelements. If `options_cont.detectEvent>0`, it allows the detection of ZH, HH points.
+- `compute_eigen_elements = false` whether to compute eigenelements. If `options_cont.detect_event>0`, it allows the detection of ZH, HH points.
 - `kwargs` keywords arguments to be passed to the regular [`continuation`](@ref)
 
 # Simplified call:
 
-    continuationHopf(br::AbstractBranchResult, ind_hopf::Int, lens2::Lens, options_cont::ContinuationPar ;  kwargs...)
+    continuation_hopf(br::AbstractBranchResult, ind_hopf::Int, lens2::Lens, options_cont::ContinuationPar ;  kwargs...)
 
 where the parameters are as above except that you have to pass the branch `br` from the result of a call to `continuation` with detection of bifurcations enabled and `index` is the index of Hopf point in `br` that you want to refine.
 
@@ -306,7 +306,7 @@ where the parameters are as above except that you have to pass the branch `br` f
     The adjoint of the jacobian `J` is computed internally when `Jᵗ = nothing` by using `transpose(J)` which works fine when `J` is an `AbstractArray`. In this case, do not pass the jacobian adjoint like `Jᵗ = (x, p) -> transpose(d_xF(x, p))` otherwise the jacobian would be computed twice!
 
 !!! tip "Detection of Bogdanov-Takens and Bautin bifurcations"
-    In order to trigger the detection, pass `detectEvent = 1,2` in `options_cont`. Note that you need to provide `d3F` in `prob`.
+    In order to trigger the detection, pass `detect_event = 1,2` in `options_cont`. Note that you need to provide `d3F` in `prob`.
 """
 function continuation_hopf(prob_vf, alg::AbstractContinuationAlgorithm,
                 hopfpointguess::BorderedArray{vectype, Tb}, par,

--- a/src/continuation/MoorePenrose.jl
+++ b/src/continuation/MoorePenrose.jl
@@ -110,7 +110,7 @@ end
 function newton_moore_penrose(iter::AbstractContinuationIterable,
                     state::AbstractContinuationState, dotθ;
                     normN = norm,
-                    callback = cbDefault, kwargs...)
+                    callback = cb_default, kwargs...)
     prob = iter.prob
     par = getparams(prob)
     ϵ = getdelta(prob)

--- a/src/continuation/Multiple.jl
+++ b/src/continuation/Multiple.jl
@@ -82,7 +82,7 @@ function corrector!(_state::AbstractContinuationState, it::AbstractContinuationI
     # we create a copy of the continuation cache
     state = copy(_state)
     @unpack ds = state
-    (verbose > 1) && printstyled(color=:magenta, "──"^35*"\n   ┌─MultiplePred tangent predictor\n")
+    (verbose > 1) && printstyled(color=:magenta, "──"^35*"\n   ┌─Multiple tangent predictor\n")
     # we combine the callbacks for the newton iterations
     cb = (state; k...) -> callback(it)(state; k...) && algo(state; k...)
     # note that z_pred already contains ds * τ, hence ii=0 corresponds to this case

--- a/src/continuation/Palc.jl
+++ b/src/continuation/Palc.jl
@@ -215,7 +215,7 @@ function gettangent!(state::AbstractContinuationState,
                                         J, dFdl,
                                         0*state.z.u, one(T)) # Right-hand side
 
-    ~flag && @warn "Linear solver failed to converge in tangent computation with type ::BorderedPred"
+    ~flag && @warn "Linear solver failed to converge in tangent computation with type ::Bordered"
 
     # we scale τ in order to have ||τ||_θ = 1 and sign <τ, τold> = 1
     α = one(T) / sqrt(dotθ(τu, τu, τp, τp, θ))

--- a/src/events/BifurcationDetection.jl
+++ b/src/events/BifurcationDetection.jl
@@ -7,11 +7,11 @@ For example, you can use it like `continuation(args...; event = SaveAtEvent((1.,
 """
 SaveAtEvent(positions::Tuple) = ContinuousEvent(length(positions), (it, state) -> map(x -> x - getp(state), positions), ntuple(x -> "save-$x", length(positions)))
 ####################################################################################################
-# detection of Fold bifurcation, should be based on BorderedPred
+# detection of Fold bifurcation, should be based on Bordered
 """
     `FoldDetectEvent`
 
-This event implements the detection of Fold points based on the p-component of the tangent vector to the continuation curve. It is designed to work with the predictor `BorderedPred()` that you pass to `continuation` with the keyword argument `tangentAlgo`. To use it, pass `event = FoldDetectEvent` to `continuation`.
+This event implements the detection of Fold points based on the p-component of the tangent vector to the continuation curve. It is designed to work with `PALC(tangent=Bordered())` as continuation algorithm. To use it, pass `event = FoldDetectEvent` to `continuation`.
 """
 FoldDetectEvent = ContinuousEvent(1, (it, state) -> state.τ.p, ("fold",))
 ####################################################################################################

--- a/src/events/EventDetection.jl
+++ b/src/events/EventDetection.jl
@@ -246,7 +246,7 @@ EventSpecialPoint(it::ContIterable, state::ContState, Utype::Symbol, status::Sym
 # function to tell the event type based  on the coordinates of the zero
 function get_event_type(event::AbstractEvent, iter::AbstractContinuationIterable, state, verbosity, status::Symbol, interval::Tuple{T, T}, ind = :) where T
     # record information about the event point
-    userpoint = EventSpecialPoint(state, :user, status, recordFromSolution(iter), iter.normC, interval)
+    userpoint = EventSpecialPoint(state, :user, status, record_from_solution(iter), iter.normC, interval)
     (verbosity > 0) && printstyled(color=:red, "!! User point at p ≈ $(getp(state)) \n")
     return true, userpoint
 end
@@ -273,7 +273,7 @@ function get_event_type(event::AbstractContinuousEvent, iter::AbstractContinuati
         @error "Error, no event was characterized whereas one was detected. Please open an issue at https://github.com/rveltz/BifurcationKit.jl/issues. \n The events are eventValue = $(state.eventValue)"
         # we halt continuation as it will mess up the detection of events
         state.stopcontinuation = true
-        return false, EventSpecialPoint(state, Symbol(typeE), status, recordFromSolution(iter), iter.normC, interval)
+        return false, EventSpecialPoint(state, Symbol(typeE), status, record_from_solution(iter), iter.normC, interval)
     end
 
     if has_custom_labels(event)
@@ -303,7 +303,7 @@ function get_event_type(event::AbstractDiscreteEvent, iter::AbstractContinuation
         @error "Error, no event was characterized whereas one was detected. Please open an issue at https://github.com/rveltz/BifurcationKit.jl/issues. \n The events are eventValue = $(state.eventValue)"
         # we halt continuation as it will mess up the detection of events
         state.stopcontinuation = true
-        return false, EventSpecialPoint(state, Symbol(typeE), status, recordFromSolution(iter), iter.normC, interval)
+        return false, EventSpecialPoint(state, Symbol(typeE), status, record_from_solution(iter), iter.normC, interval)
     end
     if has_custom_labels(event)
         typeE = labels(event, event_index_D)
@@ -333,7 +333,7 @@ function get_event_type(event::PairOfEvents, iter::AbstractContinuationIterable,
         @error "Error, no event was characterized whereas one was detected. Please open an issue at https://github.com/rveltz/BifurcationKit.jl/issues. \n The events are eventValue = $(state.eventValue)"
         # we halt continuation as it will mess up the detection of events
         state.stopcontinuation = true
-        return false, EventSpecialPoint(state, :PairOfEvents, status, recordFromSolution(iter), iter.normC, interval)
+        return false, EventSpecialPoint(state, :PairOfEvents, status, record_from_solution(iter), iter.normC, interval)
     end
 end
 
@@ -367,6 +367,6 @@ function get_event_type(event::SetOfEvents, iter::AbstractContinuationIterable, 
         @error "Error, no event was characterized whereas one was detected. Please open an issue at https://github.com/rveltz/BifurcationKit.jl/issues. \n The events are eventValue = $(state.eventValue)"
         # we halt continuation as it will mess up the detection of events
         state.stopcontinuation = true
-        return false, EventSpecialPoint(state, :SetOfEvents, status, recordFromSolution(iter), iter.normC, interval)
+        return false, EventSpecialPoint(state, :SetOfEvents, status, record_from_solution(iter), iter.normC, interval)
     end
 end

--- a/src/periodicorbit/Floquet.jl
+++ b/src/periodicorbit/Floquet.jl
@@ -55,7 +55,7 @@ function (fl::FloquetQaD)(J, nev; kwargs...)
     σ = logvals[I]
     vp0 = minimum(abs, σ)
     if (J isa FloquetWrapper{ShootingProblem}) && vp0 > 1e-8
-        @warn "The precision on the Floquet multipliers is $vp0. Either decrease `tolStability` in the option ContinuationPar or use a different method than `FloquetQaD`"
+        @warn "The precision on the Floquet multipliers is $vp0. Either decrease `tol_stability` in the option ContinuationPar or use a different method than `FloquetQaD`"
     end
     return σ, geteigenvector(fl.eigsolver, vecs, I), cv, info
 end
@@ -422,7 +422,7 @@ end
     μ = @. Complex(1 / (1 + vals))
     vp0 = minimum(abs∘log, μ)
     if vp0 > 1e-8
-        @warn "The precision on the Floquet multipliers is $vp0. Either decrease `tolStability` in the option ContinuationPar or use a different method than `FloquetCollGEV`"
+        @warn "The precision on the Floquet multipliers is $vp0. Either decrease `tol_stability` in the option ContinuationPar or use a different method than `FloquetCollGEV`"
     end
 
     return log.(μ), Complex.(vecs[indvalid, :]), true

--- a/src/periodicorbit/Flow.jl
+++ b/src/periodicorbit/Flow.jl
@@ -19,7 +19,7 @@ function vjp(::AbstractFlow, x, par, dx, δt; k...) end
 # [Optional] The function implements the flow (or semigroup) associated to an autonomous Cauchy problem `(x, p, t) -> flow(x, p, t)`. The whole solution on the time interval [0,t] must be returned. It is not strictly necessary to provide this, it is mainly used for plotting on the user side. In the case of Poincaré Shooting, one must be able to call the flow like `evolve(fl, Val(:Full), x, par, Inf)`.
 function evolve(::AbstractFlow, ::Val{:Full}, x, par, δt; k...) end
 
-# [Optional / Internal] Serial version of the flow. Used for Matrix based jacobian (Shooting and Poincaré Shooting) and diffPoincareMap. Must return a Named Tuple `(u = ..., t = t)`
+# [Optional / Internal] Serial version of the flow. Used for Matrix based jacobian (Shooting and Poincaré Shooting) and diff_poincare_map. Must return a Named Tuple `(u = ..., t = t)`
 function evolve(fl::AbstractFlow, ::Val{:SerialTimeSol}, x, par, δt; k...) end
 
 # [Optional] Flow which returns the tuple `(t, u(t))`. Optional, mainly used for plotting on the user side.

--- a/src/periodicorbit/NormalForms.jl
+++ b/src/periodicorbit/NormalForms.jl
@@ -1,7 +1,7 @@
 """
 $(SIGNATURES)
 
-Compute the normal form of periodic orbits. Same arguments as the function `getNormalForm` for equilibria. We detail the additional keyword arguments specific to periodic orbits
+Compute the normal form of periodic orbits. Same arguments as the function `get_normal_form` for equilibria. We detail the additional keyword arguments specific to periodic orbits
 
 # Optional arguments
 - `prm = true` compute the normal form using Poincaré return map. For collocation, there will be another way to compute the normal form in the future.
@@ -259,7 +259,7 @@ function period_doubling_normal_form(pbwrap::WrapPOColl,
     if bifpt.x isa NamedTuple
         # the solution is mesh adapted, we need to restore the mesh.
         pbwrap = deepcopy(pbwrap)
-        updateMesh!(pbwrap.prob, bifpt.x._mesh )
+        update_mesh!(pbwrap.prob, bifpt.x._mesh )
         bifpt = @set bifpt.x = bifpt.x.sol
     end
     pd0 = PeriodDoubling(bifpt.x, nothing, bifpt.param, par, getlens(br), nothing, nothing, nothing, :none)

--- a/src/periodicorbit/PeriodicOrbitTrapeze.jl
+++ b/src/periodicorbit/PeriodicOrbitTrapeze.jl
@@ -944,7 +944,7 @@ This is the continuation routine for computing a periodic orbit using a function
 
 $DocStrjacobianPOTrap
 
-Note that by default, the method prints the period of the periodic orbit as function of the parameter. This can be changed by providing your `recordFromSolution` argument.
+Note that by default, the method prints the period of the periodic orbit as function of the parameter. This can be changed by providing your `record_from_solution` argument.
 """
 function continuation_potrap(prob::PeriodicOrbitTrapProblem,
             orbitguess,
@@ -1063,7 +1063,7 @@ This is the continuation routine for computing a periodic orbit using a function
 - `linear_algo` same as in [`continuation`](@ref)
 $DocStrjacobianPOTrap
 
-Note that by default, the method prints the period of the periodic orbit as function of the parameter. This can be changed by providing your `recordFromSolution` argument.
+Note that by default, the method prints the period of the periodic orbit as function of the parameter. This can be changed by providing your `record_from_solution` argument.
 """
 function continuation(prob::PeriodicOrbitTrapProblem,
                     orbitguess,

--- a/src/periodicorbit/PeriodicOrbits.jl
+++ b/src/periodicorbit/PeriodicOrbits.jl
@@ -479,7 +479,7 @@ Branch switching at a bifurcation point on a branch of periodic orbits (PO) spec
 - `ampfactor = 1` factor which alter the amplitude of the bifurcated solution. Useful to magnify the bifurcated solution when the bifurcated branch is very steep.
 - `detailed = false` whether to fully compute the normal form. The normal form is only used to collect the eigenvector for now.
 - `usedeflation = true` whether to use nonlinear deflation (see [Deflated problems](@ref)) to help finding the guess on the bifurcated branch
-- `recordFromSolution = (u, p) -> u[end]`, record method used in the bifurcation diagram, by default this records the period of the periodic orbit.
+- `record_from_solution = (u, p) -> u[end]`, record method used in the bifurcation diagram, by default this records the period of the periodic orbit.
 - `linear_algo = BorderingBLS()`, same as for [`continuation`](@ref)
 - `kwargs` keywords arguments used for a call to the regular [`continuation`](@ref) and the ones specific to periodic orbits (POs).
 """

--- a/src/periodicorbit/codim2/MinAugNS.jl
+++ b/src/periodicorbit/codim2/MinAugNS.jl
@@ -346,7 +346,7 @@ function continuation_ns(prob, alg::AbstractContinuationAlgorithm,
     end
 
     # the following allows to append information specific to the codim 2 continuation to the user data
-    _printsol = get(kwargs, :recordFromSolution, nothing)
+    _printsol = get(kwargs, :record_from_solution, nothing)
     _printsol2 = isnothing(_printsol) ?
         (u, p; kw...) -> (; zip(lenses, 
                 (getp(u, 𝐍𝐒)[1], p))..., 

--- a/src/periodicorbit/codim2/MinAugPD.jl
+++ b/src/periodicorbit/codim2/MinAugPD.jl
@@ -1,7 +1,7 @@
 """
 $(SIGNATURES)
 
-For an initial guess from the index of a PD bifurcation point located in ContResult.specialpoint, returns a point which will be refined using `newtonFold`.
+For an initial guess from the index of a PD bifurcation point located in ContResult.specialpoint, returns a point which will be refined using `newton_fold`.
 """
 function pd_point(br::AbstractBranchResult, index::Int)
     bptype = br.specialpoint[index].type

--- a/src/plotting/RecipesMakie.jl
+++ b/src/plotting/RecipesMakie.jl
@@ -230,7 +230,7 @@ end
 function _plot_bifdiag_makie!(ax, bd::BifDiagNode; code = (), level = (-Inf, Inf), k...)
     if ~hasbranch(bd); return; end
 
-    _bd = getBranch(bd, code)
+    _bd = get_branch(bd, code)
     _plot_bifdiag_makie!(ax, _bd.child; code = (), level = level, k...)
 
     # !! plot root branch in last so the bifurcation points do not alias, for example a 2d BP would be plot as a 1d BP if the order were reversed

--- a/src/wave/WaveProblem.jl
+++ b/src/wave/WaveProblem.jl
@@ -1,5 +1,5 @@
-abstract type abstractModulatedWaveFD <: AbstractPOFDProblem end
-abstract type abstractModulatedWaveShooting <: AbstractShootingProblem end
+abstract type AbstractModulatedWaveFD <: AbstractPOFDProblem end
+abstract type AbstractModulatedWaveShooting <: AbstractShootingProblem end
 
 """
 TWProblem(prob, ∂::Tuple, u₀; DAE = 0, jacobian::Symbol = :AutoDiff)

--- a/test/COModel.jl
+++ b/test/COModel.jl
@@ -116,7 +116,7 @@ hp_from_bt = continuation(sn_codim2, 4 , setproperties(sn_codim2.contparams, ds 
         normC = norminf,
         update_minaug_every_step = 1,
         bothside = true,
-        # recordFromSolution = (u,p; kw...) -> (x = BK.getVec(u)[1] ),
+        # record_from_solution = (u,p; kw...) -> (x = BK.getVec(u)[1] ),
         )
 
 @test hp_from_bt.kind == BK.HopfCont()

--- a/test/simple_continuation.jl
+++ b/test/simple_continuation.jl
@@ -178,7 +178,7 @@ polpred = Polynomial(Bordered(), 2, 6, x0)
 # # polpred.coeffsPar
 
 # test for polynomial predictor interpolation
-# polpred = BK.PolynomialPred(4,9,x0)
+# polpred = BK.Polynomial(4,9,x0)
 #     for (ii,v) in enumerate(LinRange(-5,1.,10))
 #         if length(polpred.arclengths)==0
 #             push!(polpred.arclengths, 0.1)
@@ -188,7 +188,7 @@ polpred = Polynomial(Bordered(), 2, 6, x0)
 #         push!(polpred.solutions, [v])
 #         push!(polpred.parameters, 1-v^2+0.001v^4)
 #     end
-#     BK.updatePred!(polpred)
+#     BK.update_pred!(polpred)
 #     polpred(-0.5)
 #
 # plot()

--- a/test/test-bordered-problem.jl
+++ b/test/test-bordered-problem.jl
@@ -48,12 +48,12 @@ pb(vcat(sol.u, 3.1), par, vcat(sol, 3.1))
 #
 # # test of _newtonBK
 # Jchan = (x0, p0) -> BK.finiteDifferences(x -> F_chan(x, p0), x0)
-# BK._newtonBK( (x,p) -> F_chan(x, p), Jchan, BorderedArray(sol, 3.1), _tau, BorderedArray(sol, 3.1), ContinuationPar(newtonOptions = optnewbd), BK.DotTheta())
+# BK._newtonBK( (x,p) -> F_chan(x, p), Jchan, BorderedArray(sol, 3.1), _tau, BorderedArray(sol, 3.1), ContinuationPar(newton_options = optnewbd), BK.DotTheta())
 #
 # # test of newton functional, with BorderedVector
 # prob = β -> BorderedProblem((x, p) -> F_chan(x, p, β), (x, p) -> g(x, p))
 #
-# PseudoArcLengthContinuation.continuationBordered(prob, BorderedArray(sol, 3.1), 0.01, ContinuationPar(newtonOptions = optnewbd, maxSteps = 4), verbosity = 0)
+# PseudoArcLengthContinuation.continuationBordered(prob, BorderedArray(sol, 3.1), 0.01, ContinuationPar(newton_options = optnewbd, max_steps = 4), verbosity = 0)
 # ####################################################################################################
 # # problem with 2 constraints
 # g2 = (x, p) -> [g(x,p[1]), p[2] - 0.01]

--- a/test/testLure.jl
+++ b/test/testLure.jl
@@ -111,7 +111,7 @@ br_po = continuation(
     ampfactor = 1., δp = 0.0051,
     # verbosity = 3,    plot = true,
     record_from_solution = (x, p) -> (return (max = getmaximum(p.prob, x, @set par_lur.β = p.p), period = getperiod(p.prob, x, @set par_lur.β = p.p))),
-    # plotSolution = plotSH,
+    # plot_solution = plotSH,
     # finalise_solution = (z, tau, step, contResult; prob = nothing, kwargs...) -> begin
     #         BK.haseigenvalues(contResult) && Base.display(contResult.eig[end].eigenvals)
     #         return z.u[end] < 30 && length(contResult.specialpoint) < 3

--- a/test/testNF.jl
+++ b/test/testNF.jl
@@ -89,9 +89,8 @@ BK.show(stdout, br2)
 BK.propertynames(br2)
 
 # automatic bifurcation diagram (Pitchfork)
-bdiag = bifurcationdiagram(prob_pf, PALC(), 2,
+bdiag = bifurcationdiagram(prob_pf, PALC(#=tangent=Bordered()=#), 2,
     (args...) -> setproperties(opts_br; p_min = -1.0, p_max = .5, ds = 0.01, dsmax = 0.05, n_inversion = 6, detect_bifurcation = 3, max_bisection_steps = 30, newton_options = (@set opt_newton.verbose=false), max_steps = 15);
-    # tangentAlgo = BorderedPred(),
     plot = false, verbosity = 0, normC = norminf)
 
 # plot(bdiag)

--- a/test/testNF.jl
+++ b/test/testNF.jl
@@ -155,7 +155,7 @@ br_snd1 = BK.continuation(prob, PALC(),
 br_snd2 = BK.continuation(
     br_snd1, 1,
     setproperties(opts_br; p_min = -1.2, p_max = 0.2, ds = 0.001, detect_bifurcation = 3, max_steps=31, n_inversion = 8, newton_options = NewtonPar(opts_br.newton_options; verbose = false), dsmin_bisection =1e-18, tol_bisection_eigenvalue=1e-11, max_bisection_steps=20); plot = false, verbosity = 0, normC = norminf,
-    # finaliseSolution = (z, tau, step, contResult) ->
+    # finalise_solution = (z, tau, step, contResult) ->
     #     (Base.display(contResult.eig[end].eigenvals) ;true)
     )
 

--- a/test/test_iterator.jl
+++ b/test/test_iterator.jl
@@ -10,11 +10,11 @@ prob = BK.BifurcationProblem(F, [0.8], 1., (@lens _))
 opt_newton0 = BK.NewtonPar(tol = 1e-11, verbose = true)
 out0 = BK.newton(prob, opt_newton0)
 
-opts = BK.ContinuationPar(dsmax = 0.1, dsmin = 1e-3, ds = -0.001, maxSteps = 130, pMin = -3., pMax = 3., saveSolEveryStep = 0, computeEigenValues = true, detectBifurcation = true, newtonOptions = NewtonPar(verbose = false))
+opts = BK.ContinuationPar(dsmax = 0.1, dsmin = 1e-3, ds = -0.001, max_steps = 130, p_min = -3., p_max = 3., save_sol_every_step = 0, detect_bifurcation = true, newton_options = NewtonPar(verbose = false))
 
 
 println("\n"*"#"^120)
-br0 = BK.continuation(F,Jac_m,[0.8],1.,(@lens _),opts;verbosity=0,recordFromSolution = (x,p) -> x[1]) #130 => 73 points
+br0 = BK.continuation(F,Jac_m,[0.8],1.,(@lens _),opts;verbosity=0,record_from_solution = (x,p) -> x[1]) #130 => 73 points
     plot(br0);title!("")
 
 br0.branch[:,:]'


### PR DESCRIPTION
Phew! I just wanted to try the Makie plot recipe, but it errored on calling `getBranch` instead of `get_branch`. I know you've been updating the naming conventions and that this is just an oversight, so I looked over the code and fixed all the leftover camelCase names I could find.

I found some other wrinkles along the way that are also fixed to the best of my ability in this PR

* Some methods of `continuation` were written using the keyword `normN`, and some examples were using this calling convention. However, reading the tests and other `continuation` methods, I believe the intention is to use `normC` in `continuation` and `bifurcationdiagram` et cetera, while `normN` is the name of the kwarg in `newton` and `predictor`. I updated the code accordingly.
* A couple of abstract types were not capitalized. Fixed that.
  - Though it seems like the `AbstractModulatedWave*` types aren't used anyway?
* Some example code and a docstring were referring to an old `tangentAlgo` keyword that I believe has been refactored into `PALC(tangent=...)`. I tried to update the docstring and example code accordingly.

Where possible I tried to update commented-out lines of code, but I skipped commented sections that span entire files or large parts of files.