### PR TITLE
Log branching errors in `bifurcationdiagram`

### DIFF
--- a/src/bifdiagram/BifurcationDiagram.jl
+++ b/src/bifdiagram/BifurcationDiagram.jl
@@ -164,8 +164,7 @@ function bifurcationdiagram!(prob::AbstractBifurcationProblem,
                 end
 
             catch ex
-            #     @error ex
-            #     return node
+                @error "Failed to compute new branch at p = $(pt.param)" exception=ex
             end
         end
     end


### PR DESCRIPTION
`bifurcationdiagram` silently swallows all exceptions during branching. This kept me in the dark about a simple method ambiguity error when trying to use a custom eigsolver---I couldn't understand why I got an amputated diagram but didn't see any warnings or errors.

So here's a proposed improvement: log every exception and include the same info that's printed when verbosity is turned on. Errors are still non-fatal, but at least the user will know about them.