### PR TITLE
Backport support for Makie@0.23 and Makie@0.24 to BifurcationKit@0.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BifurcationKit"
 uuid = "0f109fa4-8a5d-4b75-95aa-f515264e7665"
 authors = ["Romain Veltz <rveltz@salk.edu>"]
-version = "0.4.17"
+version = "0.4.18"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"


### PR DESCRIPTION
https://github.com/SciML/Catalyst.jl/pull/1337 tries to add support for Makie > 0.22 to Catalyst. However, tests and docs revealed that BifurcationKit@0.4 only allows for Makie <= 0.22.

Hence, in this PR I backported #246 and #247 to BifurcationKit@0.4, and prepared a backport release 0.4.18.

I'm currently running tests with this branch in https://github.com/SciML/Catalyst.jl/pull/1337 to confirm that no additional compat changes would be required.